### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 - [ ] src/Foreign/Haskell/Pair.agda:24,15-18 --- \_,\_ - `infixr 4` - document this in `README.Design.Fixity`
 
-- [ ] src/Tactic/RingSolver.agda:144,3-7 --- \_`⊜\_
+- [ ] src/Tactic/RingSolver.agda:144,3-7 --- \_`⊜\_ - `infix 6`
 
 - [ ] src/Tactic/RingSolver.agda:78,15-40 --- add⇒\_mul⇒\_pow⇒\_neg⇒\_sub⇒\_
 


### PR DESCRIPTION
`` infixl 6    _`⊜_ `` because 
src/Tactic/RingSolver.agda:144,3-7 ---`` _`⊜_`` : 
```
 _`⊜_ : Term → Term → Term
  x `⊜ y = quote _⊜_  $ʳ (`numberOfVariables ⟅∷⟆ x ⟨∷⟩ y ⟨∷⟩ [])
```		 
 where ` _⊜_`  is in [Tactic.RingSolver.NonReflective](https://github.com/agda/agda-stdlib/blob/master/src/Tactic/RingSolver/NonReflective.agda)
`` infixl 6 _⊜_ ``
  		 