### PR TITLE
Need fixity

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 - [ ] src/Reflection/AST/AlphaEquality.agda:86,3-306,20 --- \_=α=-AbsTerm\_, \_=α=-ArgPattern\_, \_=α=-ArgTerm\_, \_=α=-ArgsPattern\_, \_=α=-ArgsTerm\_, \_=α=-Clause\_, \_=α=-Clauses\_, \_=α=-Pattern\_, \_=α=-Sort\_, \_=α=-Telescope\_, \_=α=-Term\_
 
-- [ ] src/Tactic/RingSolver/Core/Expression.agda:27,3-5 --- ⊝\_
+- [ ] src/Tactic/RingSolver/Core/Expression.agda:27,3-5 --- ⊝\_  - `infix 8`
 
 - [ ] src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Lemmas.agda:104,1-7 --- \_⟦∷⟧?\_Lemmas-14607523571404377151
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 
 - [ ] src/Algebra/Module/Definitions/Left.agda:36,1-40,21 --- \_DistributesOverʳ\_⟶\_, \_DistributesOverˡ\_
 
-- [ ] src/Data/Container/Relation/Binary/Pointwise.agda:26,17-20 --- \_,\_
+- [ ] src/Data/Container/Relation/Binary/Pointwise.agda:26,17-20 --- \_,\_ - `infixr 4`
 
 - [ ] src/Data/Tree/AVL/Value.agda:31,8-32,18 --- \_,\_, K&\_
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
 
 - [ ] src/Relation/Nullary/Construct/Add/Extrema.agda:18,1-3 --- \_±
 
-- [ ] src/Function/Related/TypeIsomorphisms.agda:265,1-11 --- \_→-cong-⇔\_
+- [ ] src/Function/Related/TypeIsomorphisms.agda:265,1-11 --- \_→-cong-⇔\_ - `infix 3` 
 
 - [ ] src/Function/Related.agda:268,1-4 --- \_op
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,13 @@
 
 - [ ] src/Algebra/Solver/Ring/AlmostCommutativeRing.agda:79,8-33 --- \_-Raw-AlmostCommutative⟶\_
 
-- [ ] src/Relation/Unary/Properties.agda:205,1-226,4 --- \_~?, \_×?\_, \_∩?\_, \_∪?\_, \_⊎?\_, \_⊙?\_
+- [ ] src/Relation/Unary/Properties.agda:205,1-226,4 ---
+  - \_~?  `infix 10`
+  - \_×?\_ `infix 2`
+  - \_∩?\_ `infix 7`
+  - \?\_ `infix 6`
+  - \_⊎?\_ `infix 1`
+  - \_⊙?\_ `infix 2`
 
 - [ ] src/Function/Construct/Composition.agda:240,1-282,6 --- \_∘-↔\_, \_∘-↠\_, \_∘-↣\_, \_∘-↩\_, \_∘-↪\_, \_∘-⇔\_, \_∘-⟶\_, \_∘-⤖\_ - `infixr 9`
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@
 
 - [ ] src/Relation/Unary/PredicateTransformer.agda:37,1-56,3 --- \_⍮\_, ∼\_
 
-- [ ] src/Data/Container/Indexed/Combinator.agda:63,1-4 --- \_^⊥
+- [ ] src/Data/Container/Indexed/Combinator.agda:63,1-4 --- \_^⊥ -
 
-- [ ] src/Effect/Monad/Partiality.agda:590,8-11 --- \_⊥P
+- [ ] src/Effect/Monad/Partiality.agda:590,8-11 --- \_⊥P -
 
 - [ ] src/Effect/Monad/Partiality.agda:571,3-15 --- \_≡->>=-cong\_ - `infixl 1`
 
 - [ ] src/Effect/Monad/Partiality.agda:510,3-13 --- \_>>=-cong\_ - `infixl 1`
 
-- [ ] src/Effect/Monad/Partiality.agda:39,6-8 --- \_⊥
+- [ ] src/Effect/Monad/Partiality.agda:39,6-8 --- \_⊥ -
 
 - [ ] src/IO/Base.agda:62,3-74,7 --- \_<$\_, \_<<\_
 
@@ -94,9 +94,9 @@
 
 - [ ] src/Data/Tree/AVL/Value.agda:31,8-32,18 --- \_,\_, K&\_
 
-- [ ] src/Relation/Binary/Construct/Add/Extrema/NonStrict.agda:44,1-49,5 --- \_≤⊤±, ⊥±≤\_
+- [ ] src/Relation/Binary/Construct/Add/Extrema/NonStrict.agda:44,1-49,5 --- \_≤⊤±, ⊥±≤\_ -
 
-- [ ] src/Relation/Binary/Construct/Add/Infimum/NonStrict.agda:31,3-7 --- ⊥₋≤\_
+- [ ] src/Relation/Binary/Construct/Add/Infimum/NonStrict.agda:31,3-7 --- ⊥₋≤\_ -
 
 - [ ] src/Relation/Nullary/Construct/Add/Extrema.agda:18,1-3 --- \_±
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@
 
 - [ ] src/Tactic/RingSolver/Core/AlmostCommutativeRing.agda:88,8-33 --- \_-Raw-AlmostCommutative⟶\_
 
-- [ ] src/Text/Regex/Derivative/Brzozowski.agda:110,1-114,5 --- \_∈?\_, \_∉?\_
+- [ ] src/Text/Regex/Derivative/Brzozowski.agda:110,1-114,5 --- \_∈?\_, \_∉?\_ - `infix 4`
 
-- [ ] src/Text/Regex/Properties.agda:44,1-72,8 --- \_∈?[\_], \_∈?[^\_], \_∈?ε, \_∈ᴿ?\_, \_∉ᴿ?\_, []∈?\_
+- [ ] src/Text/Regex/Properties.agda:44,1-72,8 --- \_∈?[\_], \_∈?[^\_], \_∈?ε, \_∈ᴿ?\_, \_∉ᴿ?\_, []∈?\_ - `infix 4`
 
 - [ ] src/Reflection/AnnotatedAST.agda:84,3-6 --- \_,\_
 


### PR DESCRIPTION

 Those functions need a fixity. 

- [Relation.Binary.Construct.Add.Extrema.NonStrict](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Binary/Construct/Add/Extrema/NonStrict.agda)
 ```Agda 
_≤⊤± : ∀ k → k ≤± ⊤±
⊥±    ≤⊤± = ⊥±≤⊤±
[ k ] ≤⊤± = [ k ]≤⊤±
⊤±    ≤⊤± = ⊤±≤⊤± 
```
  This function establishes that the minimal element ⊥± is less than or equal to all elements k.
  ```Agda 
_≤⊤± : ∀ k → k ≤± ⊤±
⊥±    ≤⊤± = ⊥±≤⊤±
[ k ] ≤⊤± = [ k ]≤⊤±
⊤±    ≤⊤± = ⊤±≤⊤±
  ```
  This function establishes that all elements k is less than or equal to  the maximal element.
those functions were added https://github.com/agda/agda-stdlib/commit/3cefa71815735b5f0265707167669a5fa1d6f7d6


- [Relation.Binary.Construct.Add.Infimum.NonStrict](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Binary/Construct/Add/Infimum/NonStrict.agda)
```Agda 
-- Definition
infix 5 _≤₋_
data _≤₋_ : Rel (A ₋) (a ⊔ ℓ) where
  ⊥₋≤_  : (l : A ₋)         → ⊥₋    ≤₋ l
  [_] : {k l : A} → k ≤ l → [ k ] ≤₋ [ l ]
```
`⊥₋≤_ ` is a constructor 

- [Data.Container.Indexed.Combinator](https://github.com/agda/agda-stdlib/blob/master/src/Data/Container/Indexed/Combinator.agda)
``` Agda 
_^⊥ : Container I O c r → Container I O (c ⊔ r) c
(C ^⊥) .Command  o     = (c : C .Command o) → C .Response c
(C ^⊥) .Response {o} _ = C .Command o
(C ^⊥) .next     f c   = C .next c (f c)
```
https://github.com/agda/agda-stdlib/commit/747351e1675e29e882fc65e6ce54b968567648cb

- [Effect.Monad.Partiality](https://github.com/agda/agda-stdlib/blob/master/src/Effect/Monad/Partiality.agda)
```Agda 
data _⊥ (A : Set a) : Set a where
  now   : (x : A) → A ⊥
  later : (x : ∞ (A ⊥)) → A ⊥

data _⊥P : Set a → Set (Level.suc a) where
  now   : (x : A) → A ⊥P
  later : (x : ∞ (A ⊥P)) → A ⊥P
  _>>=_ : (x : A ⊥P) (f : A → B ⊥P) → B ⊥P
``` 
`data _⊥` added https://github.com/agda/agda-stdlib/commit/5c2233107f553ea55859477f47da8b2b5232b968

https://github.com/agda/agda-stdlib/commit/3aaaab9954aad70ec139fcc657e873bcec52e0e4 `data _⊥-whnf` added to the file   `infixl 1 _>>=_`
https://github.com/agda/agda-stdlib/commit/c15d12cf7a8464bd90ab1df7281f6528313b9d78 `data _⊥-whnf` changed to `data _⊥P `
 
